### PR TITLE
Show full URL in event name

### DIFF
--- a/spec/StopwatchPluginSpec.php
+++ b/spec/StopwatchPluginSpec.php
@@ -7,6 +7,8 @@ use Http\Promise\FulfilledPromise;
 use Http\Promise\RejectedPromise;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 use PhpSpec\ObjectBehavior;
 
@@ -27,13 +29,14 @@ class StopwatchPluginSpec extends ObjectBehavior
         $this->shouldImplement('Http\Client\Common\Plugin');
     }
 
-    function it_records_event(Stopwatch $stopwatch, RequestInterface $request, ResponseInterface $response)
+    function it_records_event(Stopwatch $stopwatch, RequestInterface $request, ResponseInterface $response, UriInterface $uri)
     {
         $request->getMethod()->willReturn('GET');
-        $request->getRequestTarget()->willReturn('/');
+        $request->getUri()->willReturn($uri);
+        $uri->__toString()->willReturn('http://foo.com/bar');
 
-        $stopwatch->start('GET /', 'php_http.request')->shouldBeCalled();
-        $stopwatch->stop('GET /', 'php_http.request')->shouldBeCalled();
+        $stopwatch->start('GET http://foo.com/bar', 'php_http.request')->shouldBeCalled();
+        $stopwatch->stop('GET http://foo.com/bar', 'php_http.request')->shouldBeCalled();
 
         $next = function (RequestInterface $request) use ($response) {
             return new FulfilledPromise($response->getWrappedObject());
@@ -42,13 +45,14 @@ class StopwatchPluginSpec extends ObjectBehavior
         $this->handleRequest($request, $next, function () {});
     }
 
-    function it_records_event_on_error(Stopwatch $stopwatch, RequestInterface $request)
+    function it_records_event_on_error(Stopwatch $stopwatch, RequestInterface $request, UriInterface $uri)
     {
         $request->getMethod()->willReturn('GET');
-        $request->getRequestTarget()->willReturn('/');
+        $request->getUri()->willReturn($uri);
+        $uri->__toString()->willReturn('http://foo.com/bar');
 
-        $stopwatch->start('GET /', 'php_http.request')->shouldBeCalled();
-        $stopwatch->stop('GET /', 'php_http.request')->shouldBeCalled();
+        $stopwatch->start('GET http://foo.com/bar', 'php_http.request')->shouldBeCalled();
+        $stopwatch->stop('GET http://foo.com/bar', 'php_http.request')->shouldBeCalled();
 
         $next = function (RequestInterface $request) {
             return new RejectedPromise(new NetworkException('', $request));

--- a/src/StopwatchPlugin.php
+++ b/src/StopwatchPlugin.php
@@ -58,6 +58,6 @@ final class StopwatchPlugin implements Plugin
      */
     private function getStopwatchEventName(RequestInterface $request)
     {
-        return sprintf('%s %s', $request->getMethod(), $request->getRequestTarget());
+        return sprintf('%s %s', $request->getMethod(), $request->getUri()->__toString());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Related tickets |  |
| Documentation | n/a |
| License | MIT |
#### What's in this PR?

The Request::getRequestTarget has a weird definition:

> Retrieves the message's request-target either as it will appear (for clients), as it appeared at request (for servers), or as it was specified for the instance (see withRequestTarget()).

So sometimes it will include the domain and sometimes it will only be the path. 

This PR makes sure it always is the full URL. 
