### PR TITLE
drop php 5 because build no longer works, test with php 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,29 +19,23 @@ matrix:
           # Test with lowest dependencies
         - php: 7.1
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
-        - php: 5.4
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
 
           # Test the latest stable release
-        - php: 5.4
-        - php: 5.5
-        - php: 5.6
-        - php: 7.0
         - php: 7.1
         - php: 7.2
-          env: COVERAGE=true TEST_COMMAND="composer test-ci" DEPENDENCIES="henrikbjorn/phpspec-code-coverage:^1.0"
         - php: 7.3
+          env: COVERAGE=true TEST_COMMAND="composer test-ci" DEPENDENCIES="henrikbjorn/phpspec-code-coverage:^1.0"
 
           # Force some major versions of Symfony
-        - php: 7.2
-          env: DEPENDENCIES="dunglas/symfony-lock:^2"
-        - php: 7.2
+        - php: 7.3
           env: DEPENDENCIES="dunglas/symfony-lock:^3"
-        - php: 7.2
+        - php: 7.3
           env: DEPENDENCIES="dunglas/symfony-lock:^4"
+        - php: 7.3
+          env: SYMFONY_REQUIRE="5"
 
           # Latest commit to master
-        - php: 7.2
+        - php: 7.3
           env: STABILITY="dev"
 
     allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 1.3.0 - unreleased
+
+### Added
+
+- Support for Symfony 5
+- Support PHP 7.3
+
+### Removed
+
+- PHP 5 and PHP 7.0 support
+- Symfony 2 support (disfunctional because php-http/client-commons no longer supports Symfony 2 anyways)
+
 ## 1.2.0 - 2019-01-30
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0",
-        "symfony/stopwatch": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+        "php": "^7.1",
+        "symfony/stopwatch": "^3.4 || ^4.0 || ^5.0",
         "php-http/client-common": "^1.9 || ^2.0"
     },
     "require-dev": {
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2-dev"
+            "dev-master": "1.3-dev"
         }
     },
     "prefer-stable": true,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Test with PHP 7.3
Drop tests with PHP 5

#### Why?

Drop PHP 5 because travis-ci does not properly support them anymore, and they are so outdated that we should not use them anymore.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
